### PR TITLE
Parse only first 24 hours reproted in WundergroundHourly

### DIFF
--- a/src/WundergroundHourly.h
+++ b/src/WundergroundHourly.h
@@ -52,6 +52,7 @@ class WundergroundHourly: public JsonListener {
     void doUpdate(WGHourly *hourlies, String url);
 
     int currentHour;
+    int hoursParsed;
 
 
 


### PR DESCRIPTION
Wunderground sends 36 hours of data. The current implementation would silently overwrite already collected data with the newer data.

Note: This implementation assumes the data is sorted (increasing hours), which seems to always be the case.