### PR TITLE
Added missing ZMW location ID support for updateAstronomy

### DIFF
--- a/src/WundergroundAstronomy.cpp
+++ b/src/WundergroundAstronomy.cpp
@@ -39,6 +39,10 @@ void WundergroundAstronomy::updateAstronomy(WGAstronomy *astronomy, String apiKe
   doUpdate(astronomy, "http://api.wunderground.com/api/" + apiKey + "/astronomy/lang:" + language + "/q/" + country + "/" + city + ".json");
 }
 
+void WundergroundAstronomy::updateAstronomy(WGAstronomy *astronomy, String apiKey, String language, String zmw) {
+  doUpdate(astronomy, "http://api.wunderground.com/api/" + apiKey + "/astronomy/lang:" + language + "/q/zmw:" + zmw + ".json");
+}
+
 void WundergroundAstronomy::updateAstronomyPWS(WGAstronomy *astronomy, String apiKey, String language, String pws) {
   doUpdate(astronomy, "http://api.wunderground.com/api/" + apiKey + "/astronomy/lang:" + language + "/q/pws:" + pws + ".json");
 }

--- a/src/WundergroundAstronomy.h
+++ b/src/WundergroundAstronomy.h
@@ -60,6 +60,7 @@ class WundergroundAstronomy: public JsonListener {
   public:
     WundergroundAstronomy(boolean usePM);
     void updateAstronomy(WGAstronomy *astronomy, String apiKey, String language, String country, String city);
+    void updateAstronomy(WGAstronomy *astronomy, String apiKey, String language, String zmw);
     void updateAstronomyPWS(WGAstronomy *astronomy, String apiKey, String language, String pws);
     void setPM(boolean usePM);
     virtual void whitespace(char c);


### PR DESCRIPTION
This implementation uses an overloaded function as does WundegroundClient, but contrary to WundergroundHourly.