### PR TITLE
Changed snow flurry icons

### DIFF
--- a/src/WundergroundClient.cpp
+++ b/src/WundergroundClient.cpp
@@ -764,14 +764,14 @@ String WundergroundClient::getPoP(int period) {
 
 
 String WundergroundClient::getMeteoconIcon(String iconText) {
-  if (iconText == "chanceflurries") return "F";
+  if (iconText == "chanceflurries") return "X";
   if (iconText == "chancerain") return "Q";
   if (iconText == "chancesleet") return "W";
   if (iconText == "chancesnow") return "V";
   if (iconText == "chancetstorms") return "S";
   if (iconText == "clear") return "B";
   if (iconText == "cloudy") return "Y";
-  if (iconText == "flurries") return "F";
+  if (iconText == "flurries") return "X";
   if (iconText == "fog") return "M";
   if (iconText == "hazy") return "E";
   if (iconText == "mostlycloudy") return "Y";
@@ -784,14 +784,14 @@ String WundergroundClient::getMeteoconIcon(String iconText) {
   if (iconText == "sunny") return "B";
   if (iconText == "tstorms") return "0";
 
-  if (iconText == "nt_chanceflurries") return "F";
+  if (iconText == "nt_chanceflurries") return "$";
   if (iconText == "nt_chancerain") return "7";
   if (iconText == "nt_chancesleet") return "#";
   if (iconText == "nt_chancesnow") return "#";
   if (iconText == "nt_chancetstorms") return "&";
   if (iconText == "nt_clear") return "2";
   if (iconText == "nt_cloudy") return "Y";
-  if (iconText == "nt_flurries") return "9";
+  if (iconText == "nt_flurries") return "$";
   if (iconText == "nt_fog") return "M";
   if (iconText == "nt_hazy") return "E";
   if (iconText == "nt_mostlycloudy") return "5";


### PR DESCRIPTION
The Meteocon icons used for snow flurries looked more like wind ("F") than snow flurries. I have changed the icons to "X" and "$" to use for daytime and nighttime snow flurry icons, respectively.