### PR TITLE
Minor enhancements (burn-in, date format)

### DIFF
--- a/examples/WeatherStationDemo/WeatherStationDemo.ino
+++ b/examples/WeatherStationDemo/WeatherStationDemo.ino
@@ -86,7 +86,6 @@ String OPEN_WEATHER_MAP_LANGUAGE = "de";
 const uint8_t MAX_FORECASTS = 4;
 
 #define SECS_PER_FRAME 7
-int headerOffset = 0;
 
 // Adjust according to your language
 const String WDAY_NAMES[] = {"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"};
@@ -135,7 +134,14 @@ void setReadyForWeatherUpdate();
 FrameCallback frames[] = { drawDateTime, drawCurrentWeather, drawForecast };
 int numberOfFrames = 3;
 
-OverlayCallback overlays[] = { drawHeaderOverlay };
+#define HEADERSIZE 13
+
+int headerOffset = 0;
+OverlayCallback overlays[] = { drawFooterOverlay };
+// To start with the overlay on top, use these instead:
+//int headerOffset = HEADERSIZE;
+//OverlayCallback overlays[] = { drawHeaderOverlay };
+
 int numberOfOverlays = 1;
 
 void setup() {
@@ -143,7 +149,7 @@ void setup() {
   Serial.println();
   Serial.println();
 
-  // initialize dispaly
+  // initialize display
   display.init();
   display.clear();
   display.display();
@@ -215,7 +221,7 @@ void loop() {
     if (headerOffset == 0) {
       overlays[0] = drawHeaderOverlay;
       ui.setOverlays(overlays, numberOfOverlays);
-      headerOffset = 13;
+      headerOffset = HEADERSIZE;
     } else {
       overlays[0] = drawFooterOverlay;
       ui.setOverlays(overlays, numberOfOverlays);
@@ -326,6 +332,7 @@ void drawForecastDetails(OLEDDisplay *display, int x, int y, int dayIndex) {
 
   display->setFont(Meteocons_Plain_21);
   display->drawString(x + 20, y + 12, forecasts[dayIndex].iconMeteoCon);
+
   String temp = String(forecasts[dayIndex].temp, 0) + (IS_METRIC ? "°C" : "°F");
   display->setFont(ArialMT_Plain_10);
   display->drawString(x + 20, y + 34, temp);

--- a/examples/WeatherStationDemo/WeatherStationDemo.ino
+++ b/examples/WeatherStationDemo/WeatherStationDemo.ino
@@ -184,7 +184,7 @@ void setup() {
   ui.setIndicatorDirection(LEFT_RIGHT);
 
   // You can change the transition that is used
-  // SLIDE_LEFT, SLIDE_RIGHT, SLIDE_TOP, SLIDE_DOWN
+  // SLIDE_LEFT, SLIDE_RIGHT, SLIDE_UP, SLIDE_DOWN
   ui.setFrameAnimation(SLIDE_LEFT);
 
   ui.setFrames(frames, numberOfFrames);
@@ -270,7 +270,14 @@ void drawDateTime(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, in
   display->setFont(ArialMT_Plain_10);
   String date = WDAY_NAMES[timeInfo->tm_wday];
 
-  sprintf_P(buff, PSTR("%s, %02d/%02d/%04d"), WDAY_NAMES[timeInfo->tm_wday].c_str(), timeInfo->tm_mon + 1, timeInfo->tm_mday, timeInfo->tm_year + 1900);
+  if (IS_METRIC) {
+    // DD/MM/YYYY
+    sprintf_P(buff, PSTR("%s, %02d/%02d/%04d"), WDAY_NAMES[timeInfo->tm_wday].c_str(), timeInfo->tm_mday, timeInfo->tm_mon + 1, timeInfo->tm_year + 1900);
+  } else {
+    // MM/DD/YYYY
+    sprintf_P(buff, PSTR("%s, %02d/%02d/%04d"), WDAY_NAMES[timeInfo->tm_wday].c_str(), timeInfo->tm_mon + 1, timeInfo->tm_mday, timeInfo->tm_year + 1900);
+  }
+
   if (headerOffset == 0) {
     // Date above time
     display->drawString(64 + x, 5 + y, String(buff));


### PR DESCRIPTION
This is a little hacky (I don't like the way I'm overloading headerOffset, even though "It Works") but it has the following enhancements:

* Automatically toggle the header between the bottom and the top of the screen after each weather-data update. This should help prevent burn-in by moving the static content (line, indicators, temperature units.)
* The header-on-top layout adjusts the display positions to account for the color split on two-color panels, with current conditions and forecast temperatures moved across the gap.
* Change the date format between MM/DD/YYYY and DD/MM/YYYY based on IS_METRIC
* Configurable frame dwell time (in seconds)

There are also some whitespace cleanups, and the current conditions text is moved up 2 pixels to avoid the panel gap.