### PR TITLE
Update for OpenWeatherMapForecast.cpp

### DIFF
--- a/src/OpenWeatherMapForecast.cpp
+++ b/src/OpenWeatherMapForecast.cpp
@@ -104,7 +104,7 @@ void OpenWeatherMapForecast::value(String value) {
     if (allowedHoursCount > 0) {
       time_t time = data[currentForecast].observationTime;
       struct tm* timeInfo;
-      timeInfo = localtime(&time);
+      timeInfo = gmtime(&time);
       uint8_t currentHour = timeInfo->tm_hour;
       for (uint8_t i = 0; i < allowedHoursCount; i++) {
         if (currentHour == allowedHours[i]) {


### PR DESCRIPTION
According to the openweathermap.org API documentation, the "ObservationTime" parameter refers to UTC time and therefore should not be converted to localtime. 
See https://github.com/ThingPulse/esp8266-weather-station/issues/125