### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=ESP8266 based internet connected Weather Station
 category=Display
 url=https://github.com/ThingPulse/esp8266-weather-station
 architectures=esp8266,esp32
+depends=Json Streaming Parser


### PR DESCRIPTION
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/ThingPulse/esp8266-weather-station/blob/master/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution. (impossible to test before the next release is made and has been picked up by the Library Manager indexer)
- [x] Should this code require changes to documentation I will contribute those to [https://github.com/ThingPulse/docs](https://github.com/ThingPulse/docs).

\<Description of and rationale behind this PR\>
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: I did not add the `ESP8266 and ESP32 OLED driver for SSD1306 displays` library because this is not a dependency of the library, but only the library's example sketches. However, if you prefer to also add dependencies for the example sketches, I'm happy to update this PR accordingly.