### PR TITLE
Make allowedHours const

### DIFF
--- a/src/OpenWeatherMapForecast.h
+++ b/src/OpenWeatherMapForecast.h
@@ -82,7 +82,7 @@ class OpenWeatherMapForecast: public JsonListener {
     uint8_t currentForecast;
     boolean metric = true;
     String language = "en";
-    uint8_t *allowedHours;
+    const uint8_t *allowedHours;
     uint8_t allowedHoursCount = 0;
     boolean isCurrentForecastAllowed = true;
 
@@ -98,7 +98,7 @@ class OpenWeatherMapForecast: public JsonListener {
     boolean isMetric() { return this->metric; }
     void setLanguage(String language) { this->language = language; }
     String getLanguage() { return this->language; }
-    void setAllowedHours(uint8_t *allowedHours, uint8_t allowedHoursCount) {
+    void setAllowedHours(const uint8_t *allowedHours, uint8_t allowedHoursCount) {
       this->allowedHours = allowedHours;
       this->allowedHoursCount = allowedHoursCount;
     }


### PR DESCRIPTION
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/ThingPulse/esp8266-weather-station/blob/master/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] Should this code require changes to documentation I will contribute those to [https://github.com/ThingPulse/docs](https://github.com/ThingPulse/docs).

Right now allowedHours/setAllowedHours take a plain unsigned char pointer. The allowedHours array is never modified, so it would be beneficial to have it be const so that a caller can pass in a const array without having to cast away the const.