### PR TITLE
Added "snow" to OpenWeatherMapOneCallDailyData.

### DIFF
--- a/src/OpenWeatherMapOneCall.cpp
+++ b/src/OpenWeatherMapOneCall.cpp
@@ -259,6 +259,9 @@ void OpenWeatherMapOneCall::value(String value)
     if (currentKey == "rain") {
       this->data->daily[dailyItemCounter].rain = value.toFloat();
     }
+    if (currentKey == "snow") {
+      this->data->daily[dailyItemCounter].snow = value.toFloat();
+    }
     if (currentKey == "uvi") {
       this->data->daily[dailyItemCounter].uvi = value.toFloat();
     }

--- a/src/OpenWeatherMapOneCall.h
+++ b/src/OpenWeatherMapOneCall.h
@@ -145,6 +145,8 @@ typedef struct OpenWeatherMapOneCallDailyData {
   uint8_t clouds;
   // "rain": 5.97
   float rain;
+  // "snow":	0.15
+  float snow;
   // "uvi": 4.5
   float uvi;
 


### PR DESCRIPTION
Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is compliant with the [other contributing guidelines](https://github.com/ThingPulse/esp8266-weather-station/blob/master/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] Should this code require changes to documentation I will contribute those to [https://github.com/ThingPulse/docs](https://github.com/ThingPulse/docs).

This PR is a small change to the One Call API. Currently only the "rain" key will be parsed in the daily forecast, although OWM also provides a "snow" key where available.

I have tested the change in a project of mine and it was working well. The change is small but I'm not entirely sure there are no side effects to my contribution.