### PR TITLE
Fix compilation error in MetOfficeClient.cpp

### DIFF
--- a/src/MetOfficeClient.cpp
+++ b/src/MetOfficeClient.cpp
@@ -458,6 +458,5 @@ String MetOfficeClient::getWeatherIconName(String weatherType) {
   if (weatherType == "28") return "d_thshwr"; // Thunder shower (night)
   if (weatherType == "29") return "d_thshwr"; // Thunder shower (night)
   if (weatherType == "30") return "thunder";  // Thunder
-  int weatherTypeAsInt = weatherType.toInt();
-  if (weatherTypeAsInt > 30) return "no_data";// Something unexpected has happened!
+  return "no_data" ;// Something unexpected has happened!
 }


### PR DESCRIPTION
Maybe fixes issue #198.

- [X] This PR is compliant with the [other contributing guidelines](https://github.com/ThingPulse/esp8266-weather-station/blob/master/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] Should this code require changes to documentation I will contribute those to [https://github.com/ThingPulse/docs](https://github.com/ThingPulse/docs).

With compiler option `-Werror=return-type`:
```
C:\Users\vlast\OneDrive\Dokumenty\Arduino\libraries\esp8266-weather-station\src\MetOfficeClient.cpp: In member function 'String MetOfficeClient::getWeatherIconName(String)':
C:\Users\vlast\OneDrive\Dokumenty\Arduino\libraries\esp8266-weather-station\src\MetOfficeClient.cpp:463:1: error: control reaches end of non-void function [-Werror=return-type]
463 | }
```

