### PR TITLE
Add OWM lat/lon API

### DIFF
--- a/examples/OpenWeatherMapCurrentDemo/OpenWeatherMapCurrentDemo.ino
+++ b/examples/OpenWeatherMapCurrentDemo/OpenWeatherMapCurrentDemo.ino
@@ -39,12 +39,13 @@ OpenWeatherMapCurrent client;
 // See https://docs.thingpulse.com/how-tos/openweathermap-key/
 String OPEN_WEATHER_MAP_APP_ID = "XXX";
 /*
-Go to https://openweathermap.org/find?q= and search for a location. Go through the
-result set and select the entry closest to the actual location you want to display 
-data for. It'll be a URL like https://openweathermap.org/city/2657896. The number
-at the end is what you assign to the constant below.
+Use the OWM GeoCoder API to find lat/lon for your city: https://openweathermap.org/api/geocoding-api
+Or use any other geocoding service.
+Or go to https://openweathermap.org, search for your city and monitor the calls in the browser dev console :)
  */
-String OPEN_WEATHER_MAP_LOCATION_ID = "2657896";
+// Example: Zurich, Switzerland
+float OPEN_WEATHER_MAP_LOCATION_LAT = 47.3667;
+float OPEN_WEATHER_MAP_LOCATION_LON = 8.55;
 /*
 Arabic - ar, Bulgarian - bg, Catalan - ca, Czech - cz, German - de, Greek - el,
 English - en, Persian (Farsi) - fa, Finnish - fi, French - fr, Galician - gl,
@@ -105,7 +106,7 @@ void setup() {
   OpenWeatherMapCurrentData data;
   client.setLanguage(OPEN_WEATHER_MAP_LANGUAGE);
   client.setMetric(IS_METRIC);
-  client.updateCurrentById(&data, OPEN_WEATHER_MAP_APP_ID, OPEN_WEATHER_MAP_LOCATION_ID);
+  client.updateCurrent(&data, OPEN_WEATHER_MAP_APP_ID, OPEN_WEATHER_MAP_LOCATION_LAT, OPEN_WEATHER_MAP_LOCATION_LON);
 
   Serial.println("------------------------------------");
 

--- a/examples/OpenWeatherMapForecastDemo/OpenWeatherMapForecastDemo.ino
+++ b/examples/OpenWeatherMapForecastDemo/OpenWeatherMapForecastDemo.ino
@@ -39,12 +39,13 @@ OpenWeatherMapForecast client;
 // See https://docs.thingpulse.com/how-tos/openweathermap-key/
 String OPEN_WEATHER_MAP_APP_ID = "XXX";
 /*
-Go to https://openweathermap.org/find?q= and search for a location. Go through the
-result set and select the entry closest to the actual location you want to display 
-data for. It'll be a URL like https://openweathermap.org/city/2657896. The number
-at the end is what you assign to the constant below.
+Use the OWM GeoCoder API to find lat/lon for your city: https://openweathermap.org/api/geocoding-api
+Or use any other geocoding service.
+Or go to https://openweathermap.org, search for your city and monitor the calls in the browser dev console :)
  */
-String OPEN_WEATHER_MAP_LOCATION_ID = "2657896";
+// Example: Zurich, Switzerland
+float OPEN_WEATHER_MAP_LOCATION_LAT = 47.3667;
+float OPEN_WEATHER_MAP_LOCATION_LON = 8.55;
 /*
 Arabic - ar, Bulgarian - bg, Catalan - ca, Czech - cz, German - de, Greek - el,
 English - en, Persian (Farsi) - fa, Finnish - fi, French - fr, Galician - gl,
@@ -108,7 +109,7 @@ void setup() {
   client.setLanguage(OPEN_WEATHER_MAP_LANGUAGE);
   uint8_t allowedHours[] = {0,12};
   client.setAllowedHours(allowedHours, 2);
-  uint8_t foundForecasts = client.updateForecastsById(data, OPEN_WEATHER_MAP_APP_ID, OPEN_WEATHER_MAP_LOCATION_ID, MAX_FORECASTS);
+  uint8_t foundForecasts = client.updateForecasts(data, OPEN_WEATHER_MAP_APP_ID, OPEN_WEATHER_MAP_LOCATION_LAT, OPEN_WEATHER_MAP_LOCATION_LON, MAX_FORECASTS);
   Serial.printf("Found %d forecasts in this call\n", foundForecasts);
   Serial.println("------------------------------------");
   time_t time;

--- a/examples/WeatherStationDemo/WeatherStationDemo.ino
+++ b/examples/WeatherStationDemo/WeatherStationDemo.ino
@@ -77,12 +77,13 @@ const int SDC_PIN = 4; //D4;
 // https://docs.thingpulse.com/how-tos/openweathermap-key/
 String OPEN_WEATHER_MAP_APP_ID = "XXX";
 /*
-Go to https://openweathermap.org/find?q= and search for a location. Go through the
-result set and select the entry closest to the actual location you want to display 
-data for. It'll be a URL like https://openweathermap.org/city/2657896. The number
-at the end is what you assign to the constant below.
+Use the OWM GeoCoder API to find lat/lon for your city: https://openweathermap.org/api/geocoding-api
+Or use any other geocoding service.
+Or go to https://openweathermap.org, search for your city and monitor the calls in the browser dev console :)
  */
-String OPEN_WEATHER_MAP_LOCATION_ID = "2657896";
+// Example: Zurich, Switzerland
+float OPEN_WEATHER_MAP_LOCATION_LAT = 47.3667;
+float OPEN_WEATHER_MAP_LOCATION_LON = 8.55;
 
 // Pick a language code from this list:
 // Arabic - ar, Bulgarian - bg, Catalan - ca, Czech - cz, German - de, Greek - el,
@@ -246,13 +247,13 @@ void updateData(OLEDDisplay *display) {
   drawProgress(display, 30, "Updating weather...");
   currentWeatherClient.setMetric(IS_METRIC);
   currentWeatherClient.setLanguage(OPEN_WEATHER_MAP_LANGUAGE);
-  currentWeatherClient.updateCurrentById(&currentWeather, OPEN_WEATHER_MAP_APP_ID, OPEN_WEATHER_MAP_LOCATION_ID);
+  currentWeatherClient.updateCurrent(&currentWeather, OPEN_WEATHER_MAP_APP_ID, OPEN_WEATHER_MAP_LOCATION_LAT, OPEN_WEATHER_MAP_LOCATION_LON);
   drawProgress(display, 50, "Updating forecasts...");
   forecastClient.setMetric(IS_METRIC);
   forecastClient.setLanguage(OPEN_WEATHER_MAP_LANGUAGE);
   uint8_t allowedHours[] = {12};
   forecastClient.setAllowedHours(allowedHours, sizeof(allowedHours));
-  forecastClient.updateForecastsById(forecasts, OPEN_WEATHER_MAP_APP_ID, OPEN_WEATHER_MAP_LOCATION_ID, MAX_FORECASTS);
+  forecastClient.updateForecasts(forecasts, OPEN_WEATHER_MAP_APP_ID, OPEN_WEATHER_MAP_LOCATION_LAT, OPEN_WEATHER_MAP_LOCATION_LON, MAX_FORECASTS);
 
   readyForWeatherUpdate = false;
   drawProgress(display, 100, "Done...");

--- a/src/OpenWeatherMapCurrent.cpp
+++ b/src/OpenWeatherMapCurrent.cpp
@@ -32,6 +32,9 @@ OpenWeatherMapCurrent::OpenWeatherMapCurrent() {
 void OpenWeatherMapCurrent::updateCurrent(OpenWeatherMapCurrentData *data, String appId, String location) {
   doUpdate(data, buildPath(appId, "q=" + location));
 }
+void OpenWeatherMapCurrent::updateCurrent(OpenWeatherMapCurrentData *data, String appId, float lat, float lon) {
+  doUpdate(data, buildPath(appId, "lat=" + String(lat) + "&lon=" + String(lon)));
+}
 
 void OpenWeatherMapCurrent::updateCurrentById(OpenWeatherMapCurrentData *data, String appId, String locationId) {
   doUpdate(data, buildPath(appId, "id=" + locationId));

--- a/src/OpenWeatherMapCurrent.h
+++ b/src/OpenWeatherMapCurrent.h
@@ -87,7 +87,10 @@ class OpenWeatherMapCurrent: public JsonListener {
 
   public:
     OpenWeatherMapCurrent();
+    // deprecated as per https://openweathermap.org/current#builtin
     void updateCurrent(OpenWeatherMapCurrentData *data, String appId, String location);
+    void updateCurrent(OpenWeatherMapCurrentData *data, String appId, float lat, float lon);
+    // deprecated as per https://openweathermap.org/current#builtin
     void updateCurrentById(OpenWeatherMapCurrentData *data, String appId, String locationId);
 
     void setMetric(boolean metric) {this->metric = metric;}

--- a/src/OpenWeatherMapForecast.cpp
+++ b/src/OpenWeatherMapForecast.cpp
@@ -34,6 +34,11 @@ uint8_t OpenWeatherMapForecast::updateForecasts(OpenWeatherMapForecastData *data
   return doUpdate(data, buildPath(appId, "q=" + location));
 }
 
+uint8_t OpenWeatherMapForecast::updateForecasts(OpenWeatherMapForecastData *data, String appId, float lat, float lon, uint8_t maxForecasts) {
+  this->maxForecasts = maxForecasts;
+  return doUpdate(data, buildPath(appId, "lat=" + String(lat) + "&lon=" + String(lon)));
+}
+
 uint8_t OpenWeatherMapForecast::updateForecastsById(OpenWeatherMapForecastData *data, String appId, String locationId, uint8_t maxForecasts) {
   this->maxForecasts = maxForecasts;
   return doUpdate(data, buildPath(appId, "id=" + locationId));

--- a/src/OpenWeatherMapForecast.h
+++ b/src/OpenWeatherMapForecast.h
@@ -93,7 +93,10 @@ class OpenWeatherMapForecast: public JsonListener {
 
   public:
     OpenWeatherMapForecast();
+    // deprecated as per https://openweathermap.org/current#builtin
     uint8_t updateForecasts(OpenWeatherMapForecastData *data, String appId, String location, uint8_t maxForecasts);
+    uint8_t updateForecasts(OpenWeatherMapForecastData *data, String appId, float lat, float lon, uint8_t maxForecasts);
+    // deprecated as per https://openweathermap.org/current#builtin
     uint8_t updateForecastsById(OpenWeatherMapForecastData *data, String appId, String locationId, uint8_t maxForecasts);
 
     void setMetric(boolean metric) { this->metric = metric; }


### PR DESCRIPTION
Deprecate the deprecated OWM functions.
Instead, use the lat/lon based OWM API in the examples.

Contributes to https://github.com/ThingPulse/esp8266-weather-station/issues/219